### PR TITLE
Increase default per page

### DIFF
--- a/release_notes.rb
+++ b/release_notes.rb
@@ -7,7 +7,7 @@ full_repo = ENV['GITHUB_REPO']
 user, repo = full_repo.split('/')
 
 github = Github.new(oauth_token: token, user: user, repo: repo)
-prs = github.pull_requests.list(state: 'closed', sort: 'updated', direction: 'desc')
+prs = github.pull_requests.list(state: 'closed', sort: 'updated', direction: 'desc', per_page: 50)
 
 last_release_index = prs.to_a.index do |pr|
   /Release/i =~ pr[:title]


### PR DESCRIPTION
Issue: By default, `.list` only returns 30 items per page

Changes:
- Increase default per page value to 50

NOTE: This is not an ideal solution. We should iterate through more PRs using a pagination mechanism instead, but it requires more effort